### PR TITLE
Unify Single/MultiBufferSequence behaviour: non-zero position and take-contiguous-bytes

### DIFF
--- a/src/gloss/data/bytes/core.clj
+++ b/src/gloss/data/bytes/core.clj
@@ -211,7 +211,8 @@
       this
       
       (< n byte-count)
-      (SingleBufferSequence. (-> buffer duplicate (position n) slice) (- byte-count n))
+      (SingleBufferSequence. (-> buffer duplicate (position (+ n (position buffer))) slice)
+                             (- byte-count n))
 
       :else
       nil))
@@ -231,7 +232,7 @@
       nil
 
       (<= n byte-count)
-      (-> buffer duplicate (limit (min byte-count n)) slice)))
+      (-> buffer duplicate (limit (+ (position buffer) (min byte-count n))) slice)))
   (concat-bytes- [_ bufs]
     (create-buf-seq (cons buffer bufs))))
 

--- a/src/gloss/data/bytes/core.clj
+++ b/src/gloss/data/bytes/core.clj
@@ -236,10 +236,10 @@
       empty-buffer
 
       (< n byte-count)
-      (-> buffer duplicate (limit (+ (position buffer) (min byte-count n))) slice)
+      (-> buffer duplicate (limit (+ (position buffer) n)) slice)
 
       :else
-      buffer))
+      (duplicate buffer)))
   (concat-bytes- [_ bufs]
     (create-buf-seq (cons buffer bufs))))
 


### PR DESCRIPTION
Because MultiBufferSequence supports buffers with non-zero positions with take and drop bytes, it was surprising that SingleBufferSequence didn't. Another way to implement this would be to slice buffers with non-zero positions in create-buf-seq. The way I've done it here seems more symmetrical with MultiBufferSequence's implementation though.

Also take-contiguous-bytes was behaving differently for Single versus Multi BufferSequence when n was <= 0 or > byte-count. Not sure what behaviour you want. As implemented here, n <= 0 returns an empty buffer and n > byte-count returns all the bytes.

I erred on the side of not calling duplicate and assuming the caller won't muck with returned buffers, but maybe that isn't safe enough. There's a single empty-buffer that's allocated and returned from take-contiguous-bytes when appropriate. Should it be duplicated or allocated each time? SingleBufferSequence take-contiguous-bytes- returns buffer in n >= byte-count case. Should that be duplicated?
