### PR TITLE
Fix for SingleBufferSequence not preserving byte ordering

### DIFF
--- a/src/gloss/data/bytes/core.clj
+++ b/src/gloss/data/bytes/core.clj
@@ -206,7 +206,7 @@
     (.rewind buffer)
     this)
   (dup-bytes- [_]
-    (SingleBufferSequence. (.duplicate buffer) byte-count))
+    (SingleBufferSequence. (duplicate buffer) byte-count))
   (drop-bytes- [this n]
     (cond
       (not (pos? n))


### PR DESCRIPTION
SingleBufferSequence now uses the byte ordering preserving duplicate for dup-bytes- instead of java's .duplicate.