### PR TITLE
Add URL to project.clj

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,6 @@
 (defproject gloss "0.2.2"
   :description "speaks in bytes, so that you don't have to"
+  :url "https://github.com/ztellman/gloss"
   :license {:name "Eclipse Public License - v 1.0"
             :url "http://www.eclipse.org/legal/epl-v10.html"
             :distribution :repo}


### PR DESCRIPTION
This makes it easier to find the code from Clojars.

My strategy is:

1. see thing I haven't heard of in someone's project.clj dependencies
2. go to https://clojars.org/thingname (https://clojars.org/gloss in this case)
3. click on the link to GitHub (or wherever)
4. now I know what that thing is!

Step 3 doesn't work without the URL being included.