### PR TITLE
add missing argument to connect-via

### DIFF
--- a/src/gloss/io.clj
+++ b/src/gloss/io.clj
@@ -182,7 +182,7 @@
                         (s/put-all! dst remainder)
                         res)))))))]
 
-    (s/connect-via src dst {:downstream? false})
+    (s/connect-via src f dst {:downstream? false})
     (s/on-drained src #(do (f []) (s/close! dst)))
 
     dst))


### PR DESCRIPTION
I'm pretty sure this was an unintentional typo you made when moving from lamina to manifold (commit 3c9b263a4). Adding the arg fixed decode-stream-headers for me.

Thanks for the great libraries!