### PR TITLE
Fix issue #48 by passing the missing callback parameter to connect-via

### DIFF
--- a/src/gloss/io.clj
+++ b/src/gloss/io.clj
@@ -182,7 +182,7 @@
                         (s/put-all! dst remainder)
                         res)))))))]
 
-    (s/connect-via src dst {:downstream? false})
+    (s/connect-via src f dst {:downstream? false})
     (s/on-drained src #(do (f []) (s/close! dst)))
 
     dst))


### PR DESCRIPTION
The exception was due to missing callback argument to connect-via.
The fix seems obvious, and solved my problem.