### PR TITLE
Properly assign private metadata to defcodec- vars

### DIFF
--- a/src/gloss/core.clj
+++ b/src/gloss/core.clj
@@ -32,7 +32,7 @@
 (defmacro defcodec-
   "Defines a private compiled frame."
   [name frame & coders]
-  `(defcodec ^:private ~name ~frame ~@coders))
+  `(defcodec ~(with-meta name (assoc (meta name) :private true)) ~frame ~@coders))
 
 (import-fn protocols/sizeof)
 


### PR DESCRIPTION
This fixes ztellman/gloss#51.

``` clojure
(defcodec- foo :byte)
#'user/foo
user> (meta #'foo)
{:private true, :line 92, :column 6, :file "*cider-repl localhost*", :name foo, :ns #namespace[user]}
user> 
```
